### PR TITLE
Add additionalPartials option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can also set additionalHelpers and precompileOptions:
 ```js
 const hbsOptions = {
         additionalHelpers: {},
+        additionalPartials: {},
         precompileOptions: {}
       }
 


### PR DESCRIPTION
Adding support for Handlebars partials by providing an `additionalPartials` property. The given partials are registered in the Handlebars runtime through `Handlebars.registerPartial`.