### PR TITLE
Add minification support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "handlebars": "^4.7.8"
   },
+  "peerDependencies": {
+    "html-minifier-terser": "^7.2.0"
+  },
   "devDependencies": {
     "@types/node": "^18.7.19",
     "esbuild": "^0.16.5"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import handlebars from "handlebars";
 import { PluginBuild, OnLoadOptions } from "esbuild";
 import { stat, readFile } from "fs/promises";
-import { minify } from "html-minifier-terser";
 
 let foundHelpers: string[] = [];
 const fileCache = new Map();
@@ -80,6 +79,7 @@ function hbs(options: HBSOptions = {}) {
           foundHelpers = [];
           let template = hb.precompile(source, compileOptions);
           if (minifyOutput) {
+            const { minify } = await import("html-minifier-terser")
             template = minify(template, {
               continueOnParseError: true,
               ...minifyOptions,


### PR DESCRIPTION
## Description
I've made changes to allow the output of Handlebars templates to be minified. This is useful for providers with HTML size limitations or other similar restrictions. The `html-minifier-terser` package is used for minification.

The changes introduce two new options:

- `minifyOutput`: Specifies whether the output should be minified.
- `minifyOptions`: Allows adding specific options for `html-minifier-terser`.

## Example

```js
const esbuild = require('esbuild');
const handlebarsPlugin = require('esbuild-handlebars-plugin');

esbuild.build({
  entryPoints: ['src/index.js'],
  bundle: true,
  outfile: 'dist/bundle.js',
  plugins: [
    handlebarsPlugin({
      minifyOutput: true,
      minifyOptions: {
        collapseWhitespace: true,
        removeComments: true,
      }
    })
  ]
});
```